### PR TITLE
Add Conductor setup for parallel coding agents

### DIFF
--- a/bin/conductor-setup
+++ b/bin/conductor-setup
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Symlink .env from repo root (where secrets live, outside worktrees)
+[ -f "$CONDUCTOR_ROOT_PATH/.env" ] && ln -sf "$CONDUCTOR_ROOT_PATH/.env" .env
+
+# Symlink Rails master key
+[ -f "$CONDUCTOR_ROOT_PATH/config/master.key" ] && ln -sf "$CONDUCTOR_ROOT_PATH/config/master.key" config/master.key
+
+# Install dependencies
+bundle install

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "setup": "bin/conductor-setup",
+    "run": "script/server"
+  }
+}

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,6 +1,6 @@
 development:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: <%= ENV.fetch('REDIS_URL', 'redis://localhost:6379/1') %>
 
 test:
   adapter: test

--- a/script/server
+++ b/script/server
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# === Port Configuration ===
+export PORT=${CONDUCTOR_PORT:-3000}
+export VITE_RUBY_PORT=$((PORT + 1000))
+
+# === Redis Isolation ===
+if [ -n "$CONDUCTOR_WORKSPACE_NAME" ]; then
+  HASH=$(printf '%s' "$CONDUCTOR_WORKSPACE_NAME" | cksum | cut -d' ' -f1)
+  REDIS_DB=$((HASH % 16))
+  export REDIS_URL="redis://localhost:6379/${REDIS_DB}"
+fi
+
+exec bin/dev


### PR DESCRIPTION
## Summary
- Adds `conductor.json`, `bin/conductor-setup`, and `script/server` to enable parallel Conductor workspaces
- Each workspace gets a unique port (derived from `CONDUCTOR_PORT`) and isolated Redis DB (derived from workspace name hash)
- Updates `config/cable.yml` to respect `REDIS_URL` env var instead of hardcoding `redis://localhost:6379/1`

## Test plan
- [ ] Run `bin/conductor-setup` — completes without errors
- [ ] Run `script/server` — Rails starts on the expected port
- [ ] Verify Redis isolation works across multiple workspaces