### PR TITLE
Fix article date format and add year validation

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,8 +1,17 @@
 class Article < ApplicationRecord
   validates :title, :slug, :body, :publish_at, presence: true
   validates :slug, uniqueness: true
+  validate :publish_at_year_is_reasonable
 
   def to_param
     slug
+  end
+
+  private
+
+  def publish_at_year_is_reasonable
+    if publish_at.present? && publish_at.year < 1900
+      errors.add(:publish_at, "year must be 1900 or later")
+    end
   end
 end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -6,7 +6,7 @@
   </nav>
   <h1 class="mt-2 mb-0 font-serif text-4xl"><%= @article.title %></h1>
   <span class="text-sm text-gray-500">
-    <%= @article.publish_at.strftime("%B %d, %Y") %>
+    <%= @article.publish_at.strftime("%B %-d, %Y") %>
   </span>
   <% if user_signed_in? %>
   <span class="flex space-x-2">


### PR DESCRIPTION
## Summary
- Remove leading zero from day in article date display (`%d` → `%-d`), so dates render as "August 7, 2022" instead of "August 07, 2022"
- Add model validation rejecting `publish_at` dates with years before 1900 to prevent accidental bogus dates like "0202"

## Test plan
- [ ] Verify article show page displays dates without leading zero on the day
- [ ] Verify creating/updating an article with a year < 1900 is rejected