### PR TITLE
Add Timeslice to homepage project list

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -13,6 +13,7 @@
     <li><a href="https://usererun.com">Rerun</a> - Mac app that captures and makes your work searchable</li>
     <li><a href="https://chops.md">Chops</a> - Browse, edit, and manage AI agent skills from your Mac</li>
     <li><a href="https://clearly.md">Clearly</a> - Clean native markdown editor for Mac</li>
+    <li><a href="https://timeslice.today">Timeslice</a> - Visual time-blocking calendar</li>
     <li><a href="https://studio.neato.fun">Studio</a> - Browser-based generative design and art creation tools</li>
     <li><a href="https://everydayisayear.ai">Every Day is a Year</a> - AI tools and trends newsletter</li>
   </ul>


### PR DESCRIPTION
Adds Timeslice (timeslice.today) — a visual time-blocking calendar — to the homepage project list.