### PR TITLE
Add Claude Code Desktop worktree setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/bin/setup-worktree\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@
 !/app/assets/builds/.keep
 
 *.DS_Store
+
+# Claude Code Desktop — per-worktree artifacts (regenerated per worktree).
+/.claude/launch.json
+/.claude/worktrees/
+/.worktree-ready

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
 web: bin/rails server
-css: bin/rails tailwindcss:watch
+css: bin/rails tailwindcss:watch[always]

--- a/bin/desktop-dev
+++ b/bin/desktop-dev
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Per-worktree dev launcher for Claude Code Desktop.
+#
+# Each git worktree gets its own DETERMINISTIC port + isolated Redis DB index
+# so multiple Desktop sessions run in parallel without colliding. Pointed to by
+# .claude/launch.json's "runtimeExecutable"; execs the normal bin/dev (foreman).
+set -e
+
+cd "$(dirname "$0")/.."
+WORKTREE_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$WORKTREE_ROOT"
+
+# Force UTF-8 — Desktop's launcher inherits a minimal env with no LANG.
+export LANG="${LANG:-en_US.UTF-8}"
+export LC_ALL="${LC_ALL:-en_US.UTF-8}"
+
+# Deterministic per-worktree slots. cksum(worktree_root:app:service) is stable
+# for a worktree and differs across worktrees. Salt per service so each slot is
+# independent.
+hash_of() { printf '%s' "$1" | cksum | cut -d' ' -f1; }
+APP_ID="web"
+
+# Rails server port — honor a PORT injected by Desktop (autoPort), else derive.
+export PORT="${PORT:-$(( 30000 + $(hash_of "$WORKTREE_ROOT:$APP_ID") % 10000 ))}"
+
+# Action Cable Redis DB index (0..15) — cable.yml reads REDIS_URL.
+export REDIS_URL="redis://localhost:6379/$(( $(hash_of "$WORKTREE_ROOT:$APP_ID:redis") % 16 ))"
+
+# Per-worktree overrides win at runtime if present.
+if [ -f .env.local ]; then set -a; . ./.env.local; set +a; fi
+
+exec ./bin/dev

--- a/bin/setup-worktree
+++ b/bin/setup-worktree
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# One-time per-worktree setup for Claude Code Desktop.
+#
+# Wired to the SessionStart hook in .claude/settings.json. Two parts:
+#   1. ALWAYS: regenerate .claude/launch.json so the preview port matches THIS
+#      worktree (a moved/new worktree hashes to a different port).
+#   2. FIRST RUN: bundle install + prepare the database, guarded by a marker so
+#      re-runs are a fast no-op.
+set -e
+
+cd "$(dirname "$0")/.."
+WORKTREE_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$WORKTREE_ROOT"
+
+hash_of() { printf '%s' "$1" | cksum | cut -d' ' -f1; }
+
+# === Always: regenerate launch.json with this worktree's port ===============
+# APP_ID must match bin/desktop-dev exactly, or the preview opens the wrong port.
+mkdir -p "$WORKTREE_ROOT/.claude"
+APP_ID="web"
+APP_PORT=$(( 30000 + $(hash_of "$WORKTREE_ROOT:$APP_ID") % 10000 ))
+cat > "$WORKTREE_ROOT/.claude/launch.json" <<JSON
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "joshpigford.com",
+      "runtimeExecutable": "./bin/desktop-dev",
+      "runtimeArgs": [],
+      "autoPort": true,
+      "port": ${APP_PORT}
+    }
+  ]
+}
+JSON
+
+# === Fast-path: already set up ==============================================
+if [ -e .worktree-ready ]; then
+  echo "[setup-worktree] already configured — skipping first-run setup"
+  exit 0
+fi
+
+# === First-run setup ========================================================
+echo "[setup-worktree] first-run: installing gems + preparing database"
+bundle install
+bin/rails db:prepare
+
+touch .worktree-ready

--- a/bin/setup-worktree
+++ b/bin/setup-worktree
@@ -34,6 +34,21 @@ cat > "$WORKTREE_ROOT/.claude/launch.json" <<JSON
 }
 JSON
 
+# === Always: symlink .env from the main checkout ===========================
+# .env is gitignored, so a fresh worktree doesn't get it. Link back to the main
+# checkout (single source of truth — edits there propagate to every worktree).
+# Only do this in an actual worktree, never the main checkout, or we'd create a
+# self-referential .env -> ./.env loop. git-dir differs from git-common-dir only
+# inside a worktree.
+GIT_DIR_REL="$(git rev-parse --git-dir 2>/dev/null || true)"
+GIT_COMMON_REL="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [ -n "$GIT_COMMON_REL" ] && [ "$GIT_DIR_REL" != "$GIT_COMMON_REL" ]; then
+  MAIN="$(cd "$(dirname "$GIT_COMMON_REL")" && pwd -P)"
+  if [ -f "$MAIN/.env" ] && [ "$MAIN" != "$(pwd -P)" ]; then
+    ln -sf "$MAIN/.env" .env
+  fi
+fi
+
 # === Fast-path: already set up ==============================================
 if [ -e .worktree-ready ]; then
   echo "[setup-worktree] already configured — skipping first-run setup"


### PR DESCRIPTION
Makes the repo boot a working preview in Claude Code Desktop, with each git worktree getting its own collision-free port and Redis DB index so multiple Desktop sessions run in parallel.

## What changed
- **`bin/desktop-dev`** — boot wrapper pointed to by `launch.json`. Derives a deterministic `PORT` and `REDIS_URL` (Redis DB index) from the worktree path via `cksum`, then execs the normal `bin/dev` (foreman).
- **`bin/setup-worktree`** — `SessionStart` hook. Always regenerates `.claude/launch.json` with this worktree's port; on first run does `bundle install` + `bin/rails db:prepare`, guarded by a `.worktree-ready` marker.
- **`.claude/settings.json`** — wires the setup script to the `SessionStart` hook.
- **`Procfile.dev`** — `tailwindcss:watch` → `tailwindcss:watch[always]`. The plain watcher exits on stdin EOF when run without a TTY (as Desktop does), and foreman's "one dies, all die" then killed the web server. `[always]` keeps it alive; no change to interactive `bin/dev` behavior.
- **`.gitignore`** — ignores per-worktree artifacts (`.claude/launch.json`, `.claude/worktrees/`, `.worktree-ready`).

## Why
Without this, two worktrees both bind `:3000` and share one Redis DB, so parallel Desktop previews collide. Port + Redis index are now derived per worktree path.

## Reviewer notes
- **Shared Postgres:** isolation covers port + Redis index only; all worktrees share the `joshpigfordcom_development` database. A migration in one worktree affects the others. Per-worktree DBs can be added later if needed.
- `.claude/launch.json` is generated per worktree and gitignored — only the scripts, hook config, `Procfile.dev`, and `.gitignore` are committed.

## Verified
Booted `bin/desktop-dev`: Puma bound `127.0.0.1:37787` (matching the generated `launch.json`), `curl` returned HTTP 200 twice, and the Tailwind watcher no longer kills the server. Hash derivation confirmed stable across bash/zsh/sh.