### PR TITLE
Make SSR worker port configurable via INERTIA_SSR_PORT

### DIFF
--- a/config/initializers/inertia_rails.rb
+++ b/config/initializers/inertia_rails.rb
@@ -10,11 +10,16 @@ InertiaRails.configure do |config|
   config.ssr_enabled = ViteRuby.config.ssr_build_enabled && !Rails.env.test?
   config.ssr_bundle = Rails.public_path.join("vite-ssr/ssr.js").to_s
 
-  # Conductor may inject INERTIA_SSR_URL pointing at a dead process, and the
-  # gem auto-reads INERTIA_* env vars into config. nil lets the renderer fall
-  # through to Vite dev's /__inertia_ssr endpoint in development and the
-  # Puma-plugin-spawned worker (default port 13714) in production.
-  config.ssr_url = nil
+  # In production, derive the worker URL from the same INERTIA_SSR_PORT that
+  # vite.config.ts bakes into the SSR bundle, so Rails and the worker can't
+  # drift. The port must be unique per Inertia+SSR app on a shared host.
+  # Everywhere else this clobbers to nil: Conductor may inject INERTIA_SSR_URL
+  # pointing at a dead process (the gem auto-reads INERTIA_* env vars), and
+  # nil lets the renderer fall through to Vite dev's /__inertia_ssr endpoint.
+  config.ssr_url =
+    if Rails.env.production? && ENV["INERTIA_SSR_PORT"]
+      "http://127.0.0.1:#{ENV['INERTIA_SSR_PORT']}"
+    end
 
   # Pin the layout to an explicit name so the SSR-body render path
   # (render html: ssr['body'], layout:) always resolves application.html.erb.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
         // Rails only ever connects via localhost; don't expose the worker's
         // unauthenticated /render and /shutdown endpoints on all interfaces.
         host: '127.0.0.1',
+        // Baked into the bundle at build time, so INERTIA_SSR_PORT must be set
+        // when `vite build --ssr` runs (assets:precompile), not just at boot.
+        // Each Inertia+SSR app on a shared host needs a unique port — the
+        // default 13714 collides with whichever app grabbed it first.
+        port: Number(process.env.INERTIA_SSR_PORT) || 13714,
       },
     }),
     react(),


### PR DESCRIPTION
## What

Fixes the production SSR failure from #10. The worker crash-loops with `EADDRINUSE: 127.0.0.1:13714` — another Inertia app on the same host owns the default port. Two compounding effects:

1. Our renders go to the **other app's** SSR worker, which can't render our components → every page falls back to CSR (the empty `<div id="app">`).
2. The crash loop never gives up: the Puma plugin's health check is answered by the other app's worker, which resets the crash counter — so it respawns Node every second, forever.

## Changes

- **vite.config.ts** — `port: Number(process.env.INERTIA_SSR_PORT) || 13714` in the SSR options. The port is baked into the bundle at build time, so the var must be present during `assets:precompile`.
- **config/initializers/inertia_rails.rb** — in production, `ssr_url` derives from the same `INERTIA_SSR_PORT` so Rails and the worker can't drift; everywhere else it still clobbers to `nil` (Conductor's stale `INERTIA_SSR_URL`, Vite dev fallthrough).

## Deploy step (required)

Set `INERTIA_SSR_PORT` in the app's environment to a port no other app on the host uses (e.g. `13716` — check what keptwell and any other Inertia+SSR apps on the box are using first), then redeploy so `assets:precompile` rebuilds the bundle with it.

## Verification

- Built with `INERTIA_SSR_PORT=13715`: worker binds 13715, `/health` answers there, nothing listening on 13714
- `RAILS_ENV=production INERTIA_SSR_PORT=13715 rails runner`: `ssr_url = "http://127.0.0.1:13715"`; development: `nil`
- 53 runs, 0 failures · `tsc --noEmit` clean