### PR TITLE
Add Granite to home page; pin package name to stop worktree lock churn

### DIFF
--- a/app/frontend/pages/Home.tsx
+++ b/app/frontend/pages/Home.tsx
@@ -21,6 +21,9 @@ export default function Home() {
         <p className="text-3xl">Dabbler. Currently building...an offensive number of things.</p>
         <ul className="text-xl mt-4">
           <li>
+            <a href="https://granite.co">Granite</a> - A vault that knows your documents
+          </li>
+          <li>
             <a href="https://initialcommit.co">Initial Commit</a> - Fractional AI &amp; product
             co-founder for startups
           </li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "intelligent-pare-583749",
+  "name": "joshpigford-com",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "joshpigford-com",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@inertiajs/react": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "joshpigford-com",
   "private": true,
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
## What changed

- Added **Granite** ([granite.co](https://granite.co)) to the home page projects list, positioned directly above Initial Commit, with the tagline "A vault that knows your documents".
- Set an explicit `name` (`joshpigford-com`) in `package.json`.

## Why

The home page addition is straightforward. The package name change fixes a recurring annoyance: with no `name` field, npm falls back to the directory name, so every fresh git worktree rewrites `package-lock.json`'s top-level `name` (and `packages[""].name`) to that worktree's random name. The lockfile had been committed with a stale per-worktree name (`intelligent-pare-583749`). Pinning the name keeps `npm install` diff-free across worktrees.

## Notes for reviewers

- Verified the Granite link renders first in the list via the local Vite/Rails preview.
- `package-lock.json` diff is just the name normalization — no dependency changes.