### PR TITLE
Add KeptWell to home page

### DIFF
--- a/app/frontend/pages/Home.tsx
+++ b/app/frontend/pages/Home.tsx
@@ -24,6 +24,9 @@ export default function Home() {
             <a href="https://granite.co">Granite</a> - A vault that knows your documents
           </li>
           <li>
+            <a href="https://keptwell.org">KeptWell</a> - Your family's medical binder, replaced
+          </li>
+          <li>
             <a href="https://initialcommit.co">Initial Commit</a> - Fractional AI &amp; product
             co-founder for startups
           </li>


### PR DESCRIPTION
## What changed

Added **KeptWell** ([keptwell.org](https://keptwell.org)) to the home page projects list, positioned below Granite, with the tagline "Your family's medical binder, replaced".

## Notes for reviewers

- Verified ordering (Granite → KeptWell → Initial Commit) and the link href via the local preview.