### PR TITLE
Fix missing HTML language declaration

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="dark">
+<html lang="en" class="dark">
   <head>
     <title><%= @meta_title ? "#{@meta_title} - Josh Pigford" : "Josh Pigford" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -4,5 +4,6 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
   test "should get home" do
     get root_path
     assert_inertia_component "Home"
+    assert_select "html[lang='en']"
   end
 end


### PR DESCRIPTION
## Ahrefs evidence

- **Project:** Josh Pigford (`9789147`)
- **Completed crawl:** `finished-at:2026-08-11T15:45:10Z`
- **Issue:** HTML lang attribute missing (`c64d7bfd-d0f4-11e7-8ed1-001e67ed4656`)
- **Affected scope:** 442 crawled pages
- **Concrete samples:** `https://joshpigford.com/`, `/projects`, `/guestbook`, `/podcasts`, and `/books` all returned HTTP 200 with `html_lang: null`.

## Root cause

The shared application layout rendered `<html class="dark">` without a language declaration. The repository's static error documents already declare `lang="en"`, establishing the site's existing language value.

## Fix

Declare `lang="en"` on the shared application layout and cover it in the homepage integration test.

## Validation

- `bundle exec rails test test/controllers/pages_controller_test.rb` — 1 run, 2 assertions, 0 failures/errors
- `bundle exec rails test` — 53 runs, 106 assertions, 0 failures/errors
- `npx tsc --noEmit` — passed
- `git diff --check` — passed

## Residual risk

Low. This changes one static HTML attribute and does not alter routes, content, indexing policy, or runtime behavior.

<!-- ahrefs-site-audit:fc1760c0fdf36997248711bc18399f00a3ddd58dd113a85ba107e266370dde7a -->
